### PR TITLE
ÆØÅ i json eksport

### DIFF
--- a/building2osm.py
+++ b/building2osm.py
@@ -1386,7 +1386,7 @@ def save_file(municipality_id, municipality_name):
 			features['features'].append(feature)
 
 	file_out = open(filename, "w")
-	json.dump(features, file_out, indent = 2)
+	json.dump(features, file_out, indent=2, ensure_ascii=False)
 	file_out.close()
 
 	message ("\tSaved %i buildings\n" % count)

--- a/municipality_split.py
+++ b/municipality_split.py
@@ -566,7 +566,7 @@ def main():
 		geojson = features2geojson(subdivisions)
 		filename = f'{subdivision_plural}_{municipality_id}_{municipality_name}.geojson'
 		with open(filename, 'w', encoding='utf-8') as file:
-			json.dump(geojson, file, indent=2)
+			json.dump(geojson, file, indent=2, ensure_ascii=False)
 		print(f'\tSaved area to "{filename}"')
 
 	print(f'\nSplitting municipality into {subdivision_plural}')
@@ -581,7 +581,7 @@ def main():
 			f'{arguments.subdivision}_{subdivision_name.replace(" ", "_")}.geojson'
 		)
 		with open(filename, 'w', encoding='utf-8') as file:
-			json.dump(geojson, file, indent=2)
+			json.dump(geojson, file, indent=2, ensure_ascii=False)
 
 		print(f"\tSaved {len(geojson['features'])} buildings to '{filename}'")
 		      


### PR DESCRIPTION
Det er ingen grunn til å la json-biblioteket gomle i seg både æ, ø og å ved eksport, når man likevel eksporterer til utf-8. Selv om JOSM gjør en god jobb med å rette opp i feilen etterpå.
Utrolig at "ensure_ascii=False" ikke er standardinnstillingen i Python 3.