### PR TITLE
Add --leftovers argument to municipality_split.py

### DIFF
--- a/municipality_split.py
+++ b/municipality_split.py
@@ -524,7 +524,6 @@ def get_arguments() -> argparse.Namespace:
 	parser.add_argument('input', help="municipality name, kode or filename from building2osm")
 	parser.add_argument('-s', '--subdivision', choices=['bydel', 'postnummer'])
 	parser.add_argument('-a', '--area', dest='save_area', action='store_true', help="saves areas as geojson",)
-	parser.add_argument('-l', '--leftovers', dest='save_leftovers', action='store_true', help="saves leftover buildings in separate file")
 	return parser.parse_args()
 
 
@@ -590,11 +589,11 @@ def main():
 		print(f"\tSaved {len(geojson['features'])} buildings to '{filename}'")
 
 	leftover_buildings = [b for b in buildings if b['properties']['ref:bygningsnr'] not in imported_refs]
-	if leftover_buildings and arguments.save_leftovers:
+	if leftover_buildings:
 		geojson = features2geojson(leftover_buildings)
 		filename = (
 			f'bygninger_{municipality_id}_{municipality_name.replace(" ", "_")}_'
-			f'{arguments.subdivision}_leftovers.geojson'
+			f'{arguments.subdivision}_andre.geojson'
 		)
 		with open(filename, 'w', encoding='utf-8') as file:
 			json.dump(geojson, file, indent=2, ensure_ascii=False)

--- a/municipality_split.py
+++ b/municipality_split.py
@@ -524,6 +524,7 @@ def get_arguments() -> argparse.Namespace:
 	parser.add_argument('input', help="municipality name, kode or filename from building2osm")
 	parser.add_argument('-s', '--subdivision', choices=['bydel', 'postnummer'])
 	parser.add_argument('-a', '--area', dest='save_area', action='store_true', help="saves areas as geojson",)
+	parser.add_argument('-l', '--leftovers', dest='save_leftovers', action='store_true', help="saves leftover buildings in separate file")
 	return parser.parse_args()
 
 
@@ -571,10 +572,13 @@ def main():
 
 	print(f'\nSplitting municipality into {subdivision_plural}')
 
+
+	imported_refs = set()
 	for subdivision in subdivisions:
 		relevant_buildings = buildings_inside_subdivision(buildings, subdivision)
 		geojson = features2geojson(relevant_buildings)
 		subdivision_name = subdivision['properties']['name']
+		imported_refs.update(b['properties']['ref:bygningsnr'] for b in geojson['features'])
 
 		filename = (
 			f'bygninger_{municipality_id}_{municipality_name.replace(" ", "_")}_'
@@ -584,9 +588,21 @@ def main():
 			json.dump(geojson, file, indent=2, ensure_ascii=False)
 
 		print(f"\tSaved {len(geojson['features'])} buildings to '{filename}'")
-		      
+
+	leftover_buildings = [b for b in buildings if b['properties']['ref:bygningsnr'] not in imported_refs]
+	if leftover_buildings and arguments.save_leftovers:
+		geojson = features2geojson(leftover_buildings)
+		filename = (
+			f'bygninger_{municipality_id}_{municipality_name.replace(" ", "_")}_'
+			f'{arguments.subdivision}_leftovers.geojson'
+		)
+		with open(filename, 'w', encoding='utf-8') as file:
+			json.dump(geojson, file, indent=2, ensure_ascii=False)
+
+		print(f"\tSaved {len(geojson['features'])} leftover buildings to '{filename}'")
+	
 	print("")
 
-		      
+
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
Hi,

I've been using the `municipality_split.py` to import buildings in Telemark by postnummer but I hadn't realized that some buildings were being discarded by the script.

I've added a new `--leftovers` / `-l` argument to the script that dumps all discarded buildings into a separate file.

I've tested it manually for the Midt-Telemark (3817) kommune and it correctly produces a file with the buildings (263 in total) that are in the original file but aren't present in any of the separate postnummer files.

I hope that helps, let me know if you need me to change anything.