### PR TITLE
Add tool for filtering out imported buildings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ Parameter:
 * <code>--subdivision valgkrets</code> - Split municipality according to electoral districts (fewer than post districts in large towns; default).
 * <code>--area</code> - Save district boundaries only (no split). Default is to save boundary file when splitting.
 
+### filter_buildings
+
+Filters the geojson import file, removing buildings that have already been
+imported.
+
+Usage:
+<code>python3 filter_buildings.py --municipality \<id\> --input \<geojson\> --output \<geojson\></code>
+
+Parameters:
+* <code>--municipality id</code> - Municipality code to use for downloading
+* <code>--input geojson</code> - Path to the input geojson file
+* <code>--output geojson</code> - Path to the output geojson file
+
 ### Notes
 * Source data is from the Cadastral registry of Kartverket
   * "INSPIRE Buildings Core2d" - Contains polygons of the building footprints.

--- a/filter_buildings.py
+++ b/filter_buildings.py
@@ -1,0 +1,75 @@
+import argparse
+import json
+import sys
+
+import requests
+
+
+def parse_ref(raw_ref):
+    return {int(ref) for ref in raw_ref.split(';') if ref}
+
+
+def run_overpass_query(query):
+    overpass_url = "https://overpass-api.de/api/interpreter"
+    params = {'data': query}
+    version = '0.8.0'
+    headers = {'User-Agent': 'building2osm/' + version}
+    request = requests.get(overpass_url,
+                           params=params,
+                           headers=headers)
+    return request.json()['elements']
+
+
+def load_osm_refs(municipality_id):
+    query_fmt = '''[out:json][timeout:60];
+                   (area[ref={}][admin_level=7][place=municipality];)->.county;
+                   nwr["ref:bygningsnr"](area.county);
+                   out tags noids;
+                '''
+    query = query_fmt.format(municipality_id)
+    elements = run_overpass_query(query)
+
+    osm_refs = set()
+    for element in elements:
+        raw_ref = element['tags']['ref:bygningsnr']
+        osm_refs |= parse_ref(raw_ref)
+
+    return osm_refs
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input', required=True)
+    parser.add_argument('--output', required=True)
+    parser.add_argument('--municipality', required=True, type=int)
+    args = parser.parse_args()
+
+    with open(args.input, 'r', encoding='utf-8') as file:
+        data = json.load(file)
+        import_buildings = data['features']
+    print('Loaded {} buildings'.format(len(import_buildings)))
+
+    osm_refs = load_osm_refs(args.municipality)
+    print('Loaded {} unique references from OSM'.format(len(osm_refs)))
+
+    def in_osm(building):
+        raw_ref = building['properties']['ref:bygningsnr']
+        building_refs = parse_ref(raw_ref)
+        return bool(building_refs & osm_refs)
+
+    missing_in_osm = [b for b in import_buildings if not in_osm(b)]
+    print('Writing {} buildings missing from OSM'.format(len(missing_in_osm)))
+
+    with open(args.output, 'w', encoding='utf-8') as file:
+        geojson = {
+                'type': 'FeatureCollection',
+                'generator': 'filter_buildings.py',
+                'features': missing_in_osm,
+                }
+        json.dump(geojson, file)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Filter the import geojson file by removing buildings where one or more
references already exist in OSM, This provides a set of buildings that
is easier to work with manually after the initial import and will work
with newer datasets that don't include building geometry, providing a
way to deal with new buildings from Kartverket.